### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ matplotlib>=2.0.0
 tensorflow>=1.0.0
 Pillow>=4.1.0
 gym>=0.8.1
-h5py>=2.7.0
+h5py
 scikit-image>=0.13.0


### PR DESCRIPTION
h5py가 2.7.1버전이 설치되게 되는데, 이러면 warning이라고 뜨지만 사실상 에러나서 6장 deep sarsa코드가 실행이 안됩니다. 그냥 최신버전 설치하게 두면 실행이 잘되어서 수정요청합니다.